### PR TITLE
Allow package to be statically linked

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@
 //  along with NineAnimator.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Foundation
 import PackageDescription
 
 let package = Package(
@@ -27,7 +26,6 @@ let package = Package(
     products: [
         .library(
             name: "NineAnimatorCommon",
-            type: .dynamic,
             targets: [ "NineAnimatorCommon" ]
         )
     ],


### PR DESCRIPTION
This is required for NineAnimator as the current build script removes all .dylib frameworks, as a method of removing unnecessary system libraries from the app.
However, this would also remove the NineAnimatorCommon library as it was also dynamically linked, resulting in broken builds.