### PR TITLE
Refactor CoreData Retrieval of User's Recents to Allow Fetch Limits

### DIFF
--- a/Sources/NineAnimatorCommon/NineAnimator.swift
+++ b/Sources/NineAnimatorCommon/NineAnimator.swift
@@ -302,7 +302,7 @@ public extension NineAnimator {
     /// Returning the list of TrackingContexts containing this reference
     func trackingContexts(containingReference reference: ListingAnimeReference) -> [TrackingContext] {
         var trackingContexts = [TrackingContext]()
-        for recentAnime in user.recentAnimes {
+        for recentAnime in user.retrieveRecents() {
             let context = trackingContext(for: recentAnime)
             if context.availableReferences.contains(reference) {
                 trackingContexts.append(context)


### PR DESCRIPTION
- Also allows for quick removal of a single recently watched anime entry