### PR TITLE
Fix WebVTT timestamp regex

### DIFF
--- a/Sources/NineAnimatorCommon/Models/Media/CompositionalPlaybackMedia.swift
+++ b/Sources/NineAnimatorCommon/Models/Media/CompositionalPlaybackMedia.swift
@@ -146,7 +146,7 @@ internal extension CompositionalPlaybackMedia {
             ).tryUnwrap()
             let timestampMutipliers: [Double] = [ 3600, 60, 1 ]
             let vttEndTimestamp = try NSRegularExpression(
-                pattern: "\\d+:\\d+:[\\d\\.]+\\s+-->\\s+(\\d+):(\\d+):([\\d\\.]+)",
+                pattern: "(?:\\d+:)?\\d+:[\\d\\.]+\\s+-->\\s+(?:(\\d+):)?(\\d+):([\\d\\.]+)",
                 options: []
             ) .lastMatch(in: vttContentString)
                 .tryUnwrap()


### PR DESCRIPTION
This commit changes the regex to capture both formats listed below by making the hh portion optional.

WebVTT timestamps can be in one of two formats:
* mm:ss.ttt
* hh:mm:ss.ttt

https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API#cue_timings


Test cases:
```
00:01.000 --> 1113131235:0018.10014
- Never drink liquid nitrogen.

00:01:14.815 -->  100155150:1510001:10008.114
- Where are we now?

00:01.000 --> 01:18.10014
- Never drink liquid nitrogen.

00:01:14.815 -->  00:01:15.123
- Where are we now?
```